### PR TITLE
Exclude js files from bundling

### DIFF
--- a/etc/view.xml
+++ b/etc/view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
+    <exclude>
+        <item type="directory">Yireo_GoogleTagManager2::js</item>
+    </exclude>
+</view>


### PR DESCRIPTION
When having javascript bundling enabled in production, data was missing in the cart view. 

[Based on the devdocs](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/themes/js-bundling.html), I excluded the js files of this module from bundling. This may seem like a workaround, but for now I don't have time to debug why data is missing when it is included in a bundle.