### PR TITLE
Fix order data not being loaded yet when consumed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 phpunit-log/
+.idea/


### PR DESCRIPTION
This fix is primarily targeted on the order success page. 

Since Magento 2.2.4, we're missing order data on the order success page. After some research, I found that the dataLayer is populated before the `yireo-gtm-order` customer data has been loaded.

I did the following to fix the issue:
- Refactor getCartSpecificAttributes to work with callbacks instead of return statements
- Add a fallback for situations where the quote is empty AND the order 'seems' empty, to hard reload the `yireo-gtm-order` customer data. Then the script waits for it to be done and call the callback with the new order data, if present.

Not too proud of this fix, but it gets the order success page dataLayer back on track on Magento 2.2.4.