### PR TITLE
Fix fallback initialization of gtm if no quote/order is loaded

### DIFF
--- a/view/frontend/web/js/generic.js
+++ b/view/frontend/web/js/generic.js
@@ -111,8 +111,13 @@ define([
             delete orderData.data_id;
             if (!_.isEmpty(orderData)) {
                 callback(orderData);
+                return;
             }
-        });
+
+            callback({});
+        }.fail(function () {
+            callback({});
+        }));
     };
 
     var addScriptElement = function (attributes, window, document, scriptTag, dataLayer, configId) {
@@ -132,8 +137,8 @@ define([
         'monitorCustomer': monitorCustomer,
         'monitorCheckout': monitorCheckout,
         'getCustomer': getCustomer,
-        'getQuote': getQuote(),
-        'getOrder': getOrder(),
+        'getQuote': getQuote,
+        'getOrder': getOrder,
         'isLoggedIn': isLoggedIn,
         'getCustomerSpecificAttributes': getCustomerSpecificAttributes,
         'getCartSpecificAttributes': getCartSpecificAttributes,


### PR DESCRIPTION
Pull request #39 introduced a little regression, where GTM would not get initialized when the visitor has no quote or order.