### PR TITLE
Prevent to load multiple gtm tags

### DIFF
--- a/view/frontend/web/js/generic.js
+++ b/view/frontend/web/js/generic.js
@@ -120,6 +120,7 @@ define([
         callback({});
     };
 
+    var existingNodes = [];
     var addScriptElement = function (attributes, window, document, scriptTag, dataLayer, configId) {
         window.dataLayer.push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
         var firstScript = document.getElementsByTagName(scriptTag)[0];
@@ -127,7 +128,11 @@ define([
         var dataLayerArg = (dataLayer != 'dataLayer') ? '&l=' + dataLayer : '';
         newScript.async = true;
         newScript.src = '//www.googletagmanager.com/gtm.js?id=' + configId + dataLayerArg;
-        firstScript.parentNode.insertBefore(newScript, firstScript);
+
+        if (existingNodes.indexOf(newScript.src) === -1) {
+            firstScript.parentNode.insertBefore(newScript, firstScript);
+            existingNodes.push(newScript.src);
+        }
     };
 
     return {


### PR DESCRIPTION
Hi,

We have the problem that the Google Tag Manager script tag is loaded multiple times on product info page. I'm not sure if this is the best solution as i only partially understand what Google Tag Manager does, but maybe this change helps.