### PR TITLE
Use currency code instead of currency symbol

### DIFF
--- a/CustomerData/Order.php
+++ b/CustomerData/Order.php
@@ -13,7 +13,6 @@ namespace Yireo\GoogleTagManager2\CustomerData;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Customer\CustomerData\SectionSourceInterface;
-use Magento\Directory\Model\Currency;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -40,25 +39,17 @@ class Order implements SectionSourceInterface
     private $scopeConfig;
 
     /**
-     * @var Currency
-     */
-    private $currency;
-
-    /**
      * Order constructor.
      *
      * @param CheckoutSession $checkoutSession
      * @param ScopeConfigInterface $scopeConfig
-     * @param Currency $currency
      */
     public function __construct(
         CheckoutSession $checkoutSession,
-        ScopeConfigInterface $scopeConfig,
-        Currency $currency
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->scopeConfig = $scopeConfig;
-        $this->currency = $currency;
     }
 
     /**
@@ -126,7 +117,7 @@ class Order implements SectionSourceInterface
      */
     private function getBaseCurrency(): string
     {
-        return (string) $this->currency->getCurrencySymbol();
+        return (string) $this->order->getOrderCurrencyCode();
     }
 
     /**

--- a/CustomerData/Quote.php
+++ b/CustomerData/Quote.php
@@ -12,7 +12,6 @@ namespace Yireo\GoogleTagManager2\CustomerData;
 
 use Magento\Checkout\Model\Cart;
 use Magento\Customer\CustomerData\SectionSourceInterface;
-use Magento\Directory\Model\Currency;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote as QuoteModel;
@@ -35,11 +34,6 @@ class Quote implements SectionSourceInterface
     private $scopeConfig;
 
     /**
-     * @var Currency
-     */
-    private $currency;
-
-    /**
      * @var Cart
      */
     private $cart;
@@ -52,18 +46,15 @@ class Quote implements SectionSourceInterface
     /**
      * @param Cart $cart
      * @param ScopeConfigInterface $scopeConfig
-     * @param Currency $currency
      */
     public function __construct(
         Cart $cart,
-        ScopeConfigInterface $scopeConfig,
-        Currency $currency
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->cart = $cart;
         $this->order = $cart->getLastRealOrder();
         $this->quote = $cart->getQuote();
         $this->scopeConfig = $scopeConfig;
-        $this->currency = $currency;
     }
 
     /**
@@ -109,7 +100,7 @@ class Quote implements SectionSourceInterface
      */
     private function getBaseCurrency()
     {
-        return $this->currency->getCurrencySymbol();
+        return (string) $this->quote->getQuoteCurrencyCode();
     }
 
     /**

--- a/ViewModel/Success.php
+++ b/ViewModel/Success.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Yireo\GoogleTagManager2\ViewModel;
 
 use Magento\Checkout\Model\Session;
-use Magento\Directory\Model\Currency;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
@@ -52,11 +51,6 @@ class Success implements ArgumentInterface
      * @var ScopeConfigInterface
      */
     private $scopeConfig;
-    
-    /**
-     * @var Currency
-     */
-    private $currency;
 
     /**
      * Generic constructor.
@@ -65,22 +59,19 @@ class Success implements ArgumentInterface
      * @param Session $checkoutSession
      * @param OrderRepositoryInterface $orderRepository
      * @param ScopeConfigInterface $scopeConfig
-     * @param Currency $currency
      */
     public function __construct(
         Config $config,
         Generic $generic,
         Session $checkoutSession,
         OrderRepositoryInterface $orderRepository,
-        ScopeConfigInterface $scopeConfig,
-        Currency $currency
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->config = $config;
         $this->generic = $generic;
         $this->checkoutSession = $checkoutSession;
         $this->orderRepository = $orderRepository;
         $this->scopeConfig = $scopeConfig;
-        $this->currency = $currency;
     }
 
     /**
@@ -122,7 +113,7 @@ class Success implements ArgumentInterface
             'transactionTax' => (float) $order->getTaxAmount(),
             'transactionShipping' => (float) $order->getShippingAmount(),
             'transactionPayment' => $this->getPaymentLabel($order),
-            'transactionCurrency' => (string) $this->currency->getCurrencySymbol(),
+            'transactionCurrency' => (string) $order->getOrderCurrencyCode(),
             'transactionPromoCode' => (string) $order->getCouponCode(),
             'transactionProducts' => $this->getItemsAsArray($order)
         ];


### PR DESCRIPTION
When using multiple currencies, the currency displayed in the data layer may be wrong.
Instead, I used the quote/order currency, and replaced the symbol by the code, as many currencies can share the same symbol.