### PR TITLE
Fix error on cart configure page

### DIFF
--- a/ViewModel/Product.php
+++ b/ViewModel/Product.php
@@ -59,7 +59,12 @@ class Product implements ArgumentInterface, ProductViewModelInterface
      */
     public function getCurrentProduct(): ProductInterface
     {
-        return $this->productRepository->getById((int)$this->request->getParam('id'));
+        $productId = $this->request->getParam('product_id');
+        if (!$productId) {
+            $productId = $this->request->getParam('id');
+        }
+
+        return $this->productRepository->getById((int)$productId);
     }
 
     /**


### PR DESCRIPTION
When you have a product in the cart and want to edit/configure the product from there (click on the edit button), the URL looks e.g. like `https://app.shop.test/en/checkout/cart/configure/id/107707/product_id/38/`. This causes a `NoSuchEntityException` as `id` doesn't give us the current product in this case.