### PR TITLE
Fix duplicate product loading

### DIFF
--- a/ViewModel/Product.php
+++ b/ViewModel/Product.php
@@ -14,6 +14,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Yireo\GoogleTagManager2\Api\AttributesViewModelInterface;
 use Yireo\GoogleTagManager2\Api\ProductViewModelInterface;
 
@@ -46,11 +47,13 @@ class Product implements ArgumentInterface, ProductViewModelInterface
     public function __construct(
         RequestInterface $request,
         AttributesViewModelInterface $attributesViewModel,
-        ProductRepositoryInterface $productRepository
+        ProductRepositoryInterface $productRepository,
+        StoreManagerInterface $storeManager
     ) {
         $this->request = $request;
         $this->attributesViewModel = $attributesViewModel;
         $this->productRepository = $productRepository;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -64,7 +67,7 @@ class Product implements ArgumentInterface, ProductViewModelInterface
             $productId = $this->request->getParam('id');
         }
 
-        return $this->productRepository->getById((int)$productId);
+        return $this->productRepository->getById((int)$productId, false, $this->storeManager->getStore()->getId());
     }
 
     /**


### PR DESCRIPTION
In `\Magento\Catalog\Helper\Product::initProduct`, Magento loads the current product via:

    $this->productRepository->getById($productId, false, $this->_storeManager->getStore()->getId());

In `\Magento\Catalog\Model\ProductRepository::getById`, the product repository has a cache, which depends on the edit mode and on the store ID. Currently, we do not load the product with a store ID, which results in a different cache key, so that the product is loaded one more time from the database, which is a performance issue. Passing the same parameters to the `getById` call ensures we get the already cached product instance without any performance penalty.