### PR TITLE
Fix Duplicate Product Tracking

### DIFF
--- a/Plugin/AddDataToCartSection.php
+++ b/Plugin/AddDataToCartSection.php
@@ -169,7 +169,7 @@ class AddDataToCartSection
         $quote = $this->quote;
         $data = [];
 
-        foreach ($quote->getItemsCollection() as $item) {
+        foreach ($quote->getAllVisibleItems() as $item) {
             /** @var Item $item */
             $data[] = [
                 'productId' => $item->getProduct()->getId(),

--- a/ViewModel/Success.php
+++ b/ViewModel/Success.php
@@ -106,7 +106,7 @@ class Success implements ArgumentInterface
     {
         $data = [];
 
-        foreach ($order->getItemsCollection() as $item) {
+        foreach ($order->getItemsCollection([], true) as $item) {
             /** @var Item $item */
             $data[] = [
                 'productId' => $item->getProductId(),


### PR DESCRIPTION
If a configurable product is currently added to the cart / ordered, the simple **and** the configurable product end up in the `transactionProducts` property. This is weird and also does not match the M1 behaviour:

* https://github.com/yireo-magento1/Yireo_GoogleTagManager/blob/66137baea8f9f8e6e2bdb0fc29e99e5fb99a2ddb/source/app/code/community/Yireo/GoogleTagManager/Block/Quote.php#L54
* https://github.com/yireo-magento1/Yireo_GoogleTagManager/blob/66137baea8f9f8e6e2bdb0fc29e99e5fb99a2ddb/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php#L62