### PR TITLE
Add additional field for ecommerce push

### DIFF
--- a/ViewModel/Success.php
+++ b/ViewModel/Success.php
@@ -113,6 +113,7 @@ class Success implements ArgumentInterface
             /** @var Item $item */
             $itemData = [
                 'productId' => $item->getProductId(),
+                'id' => $item->getProductId(),
                 'sku' => $item->getSku(),
                 'name' => $item->getName(),
                 'price' => $item->getPriceInclTax(),


### PR DESCRIPTION
According to https://developers.google.com/analytics/devguides/collection/ua/gtm/enhanced-ecommerce#checkout and our SEO contact, the `ecommerce` push wants to have an `id` property on the items. It should be safe to just pass the ID in a `productId` **and** `id` property. This way, it should work for the normal push and the `ecommerce` push and we do not need to duplicate the method.