### PR TITLE
Update ecommerce attributes

### DIFF
--- a/ViewModel/Success.php
+++ b/ViewModel/Success.php
@@ -146,16 +146,17 @@ class Success implements ArgumentInterface
     private function getEcommerceAttributesAsArray(OrderInterface $order): array
     {
         return [
-            'purchase' => [
+            'currencyCode' => (string)$order->getOrderCurrencyCode(),
+            'purchase'     => [
                 'actionField' => [
-                    'id' => $this->getTransactionId($order),
+                    'id'          => $this->getTransactionId($order),
                     'affiliation' => $this->getTransactionAffiliation(),
-                    'revenue' => $this->getTransactionTotal($order),
-                    'tax' => $this->getTransactionTax($order),
-                    'shipping' => $this->getTransactionShipping($order),
-                    'coupon' => $this->getTransactionPromoCode($order),
+                    'revenue'     => $this->getTransactionTotal($order),
+                    'tax'         => $this->getTransactionTax($order),
+                    'shipping'    => $this->getTransactionShipping($order),
+                    'coupon'      => $this->getTransactionPromoCode($order),
                 ],
-                'products' => $this->getItemsAsArray($order),
+                'products'    => $this->getItemsAsArray($order),
             ],
         ];
     }


### PR DESCRIPTION
According to https://developers.google.com/analytics/devguides/collection/ua/gtm/enhanced-ecommerce#add, https://developers.google.com/analytics/devguides/collection/ua/gtm/enhanced-ecommerce#product-impressions  we should have  `'currencyCode'` as the first node in the `ecommerce` array.

This PR adds this.