### PR TITLE
Prevent failure when no eav attribute set in the config

### DIFF
--- a/DataLayer/Mapper/CategoryDataMapper.php
+++ b/DataLayer/Mapper/CategoryDataMapper.php
@@ -56,6 +56,6 @@ class CategoryDataMapper
      */
     private function getCategoryFields(): array
     {
-        return array_merge(['id', 'name'], $this->config->getCategoryEavAttributeCodes());
+        return array_filter(array_merge(['id', 'name'], $this->config->getCategoryEavAttributeCodes()));
     }
 }

--- a/DataLayer/Mapper/CustomerDataMapper.php
+++ b/DataLayer/Mapper/CustomerDataMapper.php
@@ -55,6 +55,6 @@ class CustomerDataMapper
      */
     private function getCustomerFields(): array
     {
-        return array_merge(['id'], $this->config->getCustomerEavAttributeCodes());
+        return array_filter(array_merge(['id'], $this->config->getCustomerEavAttributeCodes()));
     }
 }

--- a/DataLayer/Mapper/GuestDataMapper.php
+++ b/DataLayer/Mapper/GuestDataMapper.php
@@ -58,6 +58,6 @@ class GuestDataMapper
      */
     private function getGuestFields(): array
     {
-        return array_merge(['id'], $this->config->getCustomerEavAttributeCodes());
+        return array_filter(array_merge(['id'], $this->config->getCustomerEavAttributeCodes()));
     }
 }

--- a/DataLayer/Mapper/ProductDataMapper.php
+++ b/DataLayer/Mapper/ProductDataMapper.php
@@ -84,7 +84,7 @@ class ProductDataMapper
      */
     private function getProductFields(): array
     {
-        return array_merge(['name'], $this->config->getProductEavAttributeCodes());
+        return array_filter(array_merge(['name'], $this->config->getProductEavAttributeCodes()));
     }
 
     /**


### PR DESCRIPTION
I have introduced a new bug with my previous fixes. When there's no attribute selected in the config, it will return an empty string which will cause the entire object to be loaded and then pushed to the dataLayer.