### PR TITLE
Prevent duplication of items in the view_item_list event 

### DIFF
--- a/DataLayer/Tag/Cart/CartItems.php
+++ b/DataLayer/Tag/Cart/CartItems.php
@@ -13,18 +13,18 @@ class CartItems implements TagInterface
 {
     private CartInterface $cart;
     private CartItemDataMapper $cartItemDataMapper;
-    
+
     /**
      * @param CartItemDataMapper $cartItemDataMapper
-     * @param Session $checkoutSession
+     * @param Session $session
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
     public function __construct(
-        CartInterface $cart,
+        Session $session,
         CartItemDataMapper $cartItemDataMapper
     ) {
-        $this->cart = $cart;
+        $this->cart = $session->getQuote();
         $this->cartItemDataMapper = $cartItemDataMapper;
     }
 

--- a/Util/GetCurrentCategoryProducts.php
+++ b/Util/GetCurrentCategoryProducts.php
@@ -10,7 +10,7 @@ class GetCurrentCategoryProducts
 
     public function addProduct(ProductInterface $product)
     {
-        $this->products[] = $product;
+        $this->products[$product->getId()] = $product;
     }
 
     /**


### PR DESCRIPTION
Prevent duplication of items in the view_item_list event when `getLoadedProductCollection` function is called multiple times per page load.