### PR TITLE
Use core method instead of custom filter

### DIFF
--- a/DataLayer/Tag/Order/OrderItems.php
+++ b/DataLayer/Tag/Order/OrderItems.php
@@ -36,11 +36,7 @@ class OrderItems implements TagInterface
         }
 
         $orderItemsData = [];
-        foreach ($order->getAllItems() as $item) {
-            if ($item->getParentItem()) {
-                continue;
-            }
-
+        foreach ($order->getAllVisibleItems() as $item) {
             $orderItemsData[] = $this->orderItemDataMapper->mapByOrderItem($item, $order);
         }
 


### PR DESCRIPTION
This improves the fix from https://github.com/yireo/Yireo_GoogleTagManager2/pull/118. The [core method](https://github.com/magento/magento2/blob/6de20666c62dfd539d1ed032e4f7bd2ac2eb5792/app/code/Magento/Sales/Model/Order.php#L1539-L1548) filters correctly already.