### PR TITLE
Removed already loaded noscript iframe

### DIFF
--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -7,10 +7,6 @@ use Yireo\GoogleTagManager2\Config\Config;
 /** @var Template $block */
 $config = $block->getConfig();
 ?>
-<noscript>
-    <iframe src="//www.googletagmanager.com/ns.html?id=<?= /* @noEscape */
-    $config->getId() ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>
 
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
The noscript with iframe is already loaded in the iframe.phtml template, I think it should be removed in script.phtml. Am I missing anything?