### PR TITLE
Return price in the current currency for multi-currency stores

### DIFF
--- a/DataLayer/Event/AddToCart.php
+++ b/DataLayer/Event/AddToCart.php
@@ -3,6 +3,7 @@
 namespace Yireo\GoogleTagManager2\DataLayer\Event;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Pricing\Price\FinalPrice;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Yireo\GoogleTagManager2\Api\Data\EventInterface;
@@ -40,7 +41,7 @@ class AddToCart implements EventInterface
         return [
             'event' => 'add_to_cart',
             'currency' => $this->currencyCode->get(),
-            'value' => $this->product->getFinalPrice() * $this->qty,
+            'value' => $this->product->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue() * $this->qty,
             'ecommerce' => [
                 'items' => [$itemData]
             ]

--- a/DataLayer/Mapper/ProductDataMapper.php
+++ b/DataLayer/Mapper/ProductDataMapper.php
@@ -4,6 +4,7 @@ namespace Yireo\GoogleTagManager2\DataLayer\Mapper;
 
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Pricing\Price\FinalPrice;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Yireo\GoogleTagManager2\Api\Data\ProductTagInterface;
@@ -70,7 +71,9 @@ class ProductDataMapper
         } catch (NoSuchEntityException $noSuchEntityException) {
         }
 
-        $productData['price'] = $this->priceFormatter->format($product->getFinalPrice());
+        $productData['price'] = $this->priceFormatter->format(
+            $product->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue()
+        );
         $productData = $this->attachCategoriesData($product, $productData);
         $productData = $this->parseDataLayerMapping($product, $productData);
 

--- a/DataLayer/Tag/Product/CurrentPrice.php
+++ b/DataLayer/Tag/Product/CurrentPrice.php
@@ -33,7 +33,7 @@ class CurrentPrice implements TagInterface
     {
         $product = $this->getCurrentProduct->get();
         return $this->priceFormatter->format(
-            $product->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue()
+            (float) $product->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue()
         );
     }
 }

--- a/DataLayer/Tag/Product/CurrentPrice.php
+++ b/DataLayer/Tag/Product/CurrentPrice.php
@@ -2,6 +2,7 @@
 
 namespace Yireo\GoogleTagManager2\DataLayer\Tag\Product;
 
+use Magento\Catalog\Pricing\Price\FinalPrice;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Yireo\GoogleTagManager2\Api\Data\TagInterface;
 use Yireo\GoogleTagManager2\Util\GetCurrentProduct;
@@ -31,6 +32,8 @@ class CurrentPrice implements TagInterface
     public function get(): string
     {
         $product = $this->getCurrentProduct->get();
-        return $this->priceFormatter->format((float)$product->getPrice());
+        return $this->priceFormatter->format(
+            $product->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue()
+        );
     }
 }


### PR DESCRIPTION
If running a multi-currency store, when changing the currency, the prices pushed to the `dataLayer` are wrong. They're always in the base currency even if the `currency` field itself changes correctly. Getting the prices as described below seems to avoid the issue.