### PR TITLE
Return prices as numbers instead of strings

### DIFF
--- a/DataLayer/Tag/Product/CurrentPrice.php
+++ b/DataLayer/Tag/Product/CurrentPrice.php
@@ -25,10 +25,10 @@ class CurrentPrice implements TagInterface
     }
 
     /**
-     * @return string
+     * @return float
      * @throws NoSuchEntityException
      */
-    public function get(): string
+    public function get(): float
     {
         $product = $this->getCurrentProduct->get();
         return $this->priceFormatter->format((float)$product->getPrice());

--- a/Util/PriceFormatter.php
+++ b/Util/PriceFormatter.php
@@ -11,10 +11,10 @@ class PriceFormatter
 {
     /**
      * @param float $price
-     * @return string
+     * @return float
      */
-    public function format(float $price): string
+    public function format(float $price): float
     {
-        return number_format($price, 2, ".", "");
+        return (float)number_format($price, 2, ".", "");
     }
 }


### PR DESCRIPTION
I think this one is debatable because Google is permissive enough (I think).

The [documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#add_to_cart) always states that the prices should be numbers.

The change fixes that though I'm not sure it has any impact on the final result.