### PR TITLE
use tax config for prices in cart/order events

### DIFF
--- a/DataLayer/Mapper/OrderItemDataMapper.php
+++ b/DataLayer/Mapper/OrderItemDataMapper.php
@@ -5,11 +5,12 @@ namespace Yireo\GoogleTagManager2\DataLayer\Mapper;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Quote\Api\Data\CartItemInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Tax\Model\Config;
 use Yireo\GoogleTagManager2\Util\PriceFormatter;
 
 class OrderItemDataMapper
@@ -24,18 +25,21 @@ class OrderItemDataMapper
      * @param ProductDataMapper $productDataMapper
      * @param ProductRepositoryInterface $productRepository
      * @param PriceFormatter $priceFormatter
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         OrderRepositoryInterface   $orderRepository,
         ProductDataMapper          $productDataMapper,
         ProductRepositoryInterface $productRepository,
-        PriceFormatter             $priceFormatter
+        PriceFormatter             $priceFormatter,
+        ScopeConfigInterface       $scopeConfig
     )
     {
         $this->orderRepository = $orderRepository;
         $this->productDataMapper = $productDataMapper;
         $this->productRepository = $productRepository;
         $this->priceFormatter = $priceFormatter;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -54,7 +58,7 @@ class OrderItemDataMapper
             'currency' => $order->getOrderCurrencyCode(),
             'discount' => $orderItem->getDiscountAmount(),
             'quantity' => $orderItem->getQtyOrdered(),
-            'price' => $this->priceFormatter->format((float)$orderItem->getPriceInclTax())
+            'price' => $this->getPrice($orderItem)
         ];
 
         if ($orderItem->getProductType() == Configurable::TYPE_CODE) {
@@ -76,5 +80,27 @@ class OrderItemDataMapper
         }
 
         return $orderItemData;
+    }
+
+    private function getPrice(OrderItemInterface $orderItem): float
+    {
+        $displayType = (int)$this->scopeConfig->getValue(
+            Config::CONFIG_XML_PATH_PRICE_DISPLAY_TYPE,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $orderItem->getStoreId()
+        );
+
+        switch ($displayType) {
+            case Config::DISPLAY_TYPE_EXCLUDING_TAX:
+            case Config::DISPLAY_TYPE_BOTH:
+                $price = $orderItem->getPrice();
+                break;
+            case Config::DISPLAY_TYPE_INCLUDING_TAX:
+            default:
+                $price = $orderItem->getPriceInclTax();
+                break;
+        }
+
+        return $this->priceFormatter->format((float)$price);
     }
 }


### PR DESCRIPTION
I think one is debatable as well.

Magento allows displaying prices including or excluding taxes on the catalog (handled magically through the `getFinalPrice` method). The prices pushed to the data layer match that configuration. I.e. if you display prices including taxes on the catalog, then prices including taxes are pushed to the data layer.

There are 2 exceptions in the current implementation:

1. The prices pushed from the cart (they are always excluding tax): `$cartItem->getPrice()`
2. The prices pushed from the order (they are always including tax): `$orderItem->getPriceInclTax()`

From the analytics perspective, I think one would want to see the same prices through the whole purchase journey (catalog, checkout, order success). Even if there is a separate configuration setting to choose how to display the prices on cart and checkout, I think that one might break the analytics data if the settings don't match.

I'm open to suggestions.