### PR TITLE
Fix Invisible Cart Items

### DIFF
--- a/DataLayer/Tag/Cart/CartItems.php
+++ b/DataLayer/Tag/Cart/CartItems.php
@@ -33,7 +33,7 @@ class CartItems implements TagInterface
      */
     public function get(): array
     {
-        $cartItems = $this->cartModel->getQuote()->getItems();
+        $cartItems = $this->cartModel->getQuote()->getAllVisibleItems();
         if (!$cartItems) {
             return [];
         }


### PR DESCRIPTION
This fixes invisible quote items. Sometimes no items are visible.


Hidden quote items are visible | Sometimes no items are visible at all
-----|-----
<img width="630" alt="Screenshot 2023-03-06 at 12 06 40" src="https://user-images.githubusercontent.com/96116544/223093609-92a99f92-fd91-47a7-90e7-52a0c204aaeb.png"> | ![Screenshot 2023-03-06 at 12 06 58](https://user-images.githubusercontent.com/96116544/223093664-0c9b9bbf-8163-4feb-b194-adef84846e57.png)


Magento Version: 2.4.5-p1
Module Version: 3.0.14
PHP Version: 8.1