### PR TITLE
Fix product path value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.1.2] - 8 April 2023
+## [3.1.3] - 8 April 2023
 ### Fixed
 - Fixed default 'product_path' config for product clicks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.1.2] - 8 April 2023
+### Fixed
+- Fixed default 'product_path' config for product clicks
+
+## [3.1.2] - 8 April 2023
 ### Added
 - Option to only generate `view_cart` on the cart page
 - Move product clicks to separate template and make `productPath` configurable through layout

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "yireo/magento2-googletagmanager2",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "license": "OSL-3.0",
   "type": "magento2-module",
   "homepage": "https://www.yireo.com/software/magento-extensions/googletagmanager2",

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -98,7 +98,7 @@
                     after="yireo_googletagmanager2.data-layer"
             >
                 <arguments>
-                    <argument name="product-path" xsi:type="string">.product-items a.product</argument>
+                    <argument name="product_path" xsi:type="string">.product-items a.product</argument>
                 </arguments>
             </block>
         </container>


### PR DESCRIPTION
After the module has been set up and being navigated to a category page I noticed the following while viewing 'view page source' using the Chrome inspector:
```
<script>
require(['yireoGoogleTagManagerProductClicks'], function(clicks) {
    clicks({productPath: ''});
});
</script>
```

Reviewing the code value `productPath` should be filled by default due to the `default.xml` configuration for block `yireo_googletagmanager2.script-product-clicks`. This problem is caused by not using snake_case for block arguments:

```
<argument name="product-path" xsi:type="string">.product-items a.product</argument> <-- $block->getProductPath() = emtpy
<argument name="product_path" xsi:type="string">.product-items a.product</argument> <-- $block->getProductPath() = given value
```