### PR TITLE
remove trailing slash for php 7.4 compatibility

### DIFF
--- a/DataLayer/Event/Login.php
+++ b/DataLayer/Event/Login.php
@@ -13,7 +13,7 @@ class Login implements EventInterface
     private CustomerDataMapper $customerDataMapper;
 
     public function __construct(
-        CustomerDataMapper $customerDataMapper,
+        CustomerDataMapper $customerDataMapper
     ) {
         $this->customerDataMapper = $customerDataMapper;
     }


### PR DESCRIPTION
Module should be compatible with ^7.4. Trailing comma is allowed since 8.0.