### PR TITLE
GA4 container ID client-side validation

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -28,6 +28,7 @@
                     <comment>ID of your Google Tag container, starting with "GTM-"</comment>
                     <frontend_model>Yireo\GoogleTagManager2\Model\Config\Frontend\ContainerId</frontend_model>
                     <backend_model>Yireo\GoogleTagManager2\Model\Config\Backend\ContainerId</backend_model>
+                    <validate>validate-ga4-container-id</validate>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,0 +1,9 @@
+var config = {
+    config: {
+        mixins: {
+            'mage/validation': {
+                'Yireo_GoogleTagManager2/js/validation-mixin': true
+            }
+        }
+    }
+}

--- a/view/adminhtml/web/js/validation-mixin.js
+++ b/view/adminhtml/web/js/validation-mixin.js
@@ -1,0 +1,13 @@
+define([
+    'jquery'
+], function ($) {
+    'use strict'
+
+    return function(targetWidget) {
+        $.validator.addMethod('validate-ga4-container-id', function (value, element) {
+            return value.startsWith('GTM-');
+        }, $.mage.__("The container ID should start with 'GTM-'"));
+
+        return targetWidget;
+    }
+});


### PR DESCRIPTION
Show a client-side rendered validation message to prevent the configuration from being reset after saving with incorrect Container Public ID.

![Screenshot 2023-04-20 at 14 19 46](https://user-images.githubusercontent.com/6535718/233364008-efed1bdf-0535-467b-8ddf-045754fb145c.png)
