### PR TITLE
Added text field input in backend for entering a url for gtm.js. Fall…

### DIFF
--- a/Config/Config.php
+++ b/Config/Config.php
@@ -56,6 +56,20 @@ class Config implements ArgumentInterface
         return true;
     }
 
+    public function getGoogleTagmanagerUrl(): string
+    {
+        $googleTagmanagerUrl = 'www.googletagmanager.com';
+
+        if ($this->getModuleConfigValue('serverside_gtm_url')) {
+            $googleTagmanagerUrl = $this->getModuleConfigValue(
+                'serverside_gtm_url',
+                ScopeInterface::SCOPE_STORE
+            );
+        }
+
+        return $googleTagmanagerUrl;
+    }
+
     /**
      * Check whether the module is in debugging mode
      *

--- a/Config/Config.php
+++ b/Config/Config.php
@@ -56,6 +56,12 @@ class Config implements ArgumentInterface
         return true;
     }
 
+    /**
+     *
+     * Get the Google tag manager url. Defaults to googletagmanager.com. when field is filled return that url.
+     *
+     * @return string
+     */
     public function getGoogleTagmanagerUrl(): string
     {
         return $this->getModuleConfigValue(

--- a/Config/Config.php
+++ b/Config/Config.php
@@ -58,16 +58,10 @@ class Config implements ArgumentInterface
 
     public function getGoogleTagmanagerUrl(): string
     {
-        $googleTagmanagerUrl = 'www.googletagmanager.com';
-
-        if ($this->getModuleConfigValue('serverside_gtm_url')) {
-            $googleTagmanagerUrl = $this->getModuleConfigValue(
-                'serverside_gtm_url',
-                ScopeInterface::SCOPE_STORE
-            );
-        }
-
-        return $googleTagmanagerUrl;
+        return $this->getModuleConfigValue(
+            'serverside_gtm_url',
+            'https://www.googletagmanager.com'
+        );
     }
 
     /**

--- a/ViewModel/Commons.php
+++ b/ViewModel/Commons.php
@@ -52,6 +52,7 @@ class Commons implements ArgumentInterface
         $configuration['data_layer'] = $this->dataLayer->getDataLayer();
         $configuration['id'] = $this->config->getId();
         $configuration['debug'] = $this->config->isDebug();
+        $configuration['gtm_url'] = $this->config->getGoogleTagmanagerUrl();
         return $configuration;
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,9 +35,9 @@
                 </field>
                 <field id="serverside_gtm_url" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Container URL</label>
-                    <comment><![CDATA[<span>When a value is present in this field, data will send to this url instead of www.googletagmanager.com.
-                    Default output: gtm-test123.uc.r.appspot.com. Create a cname in the dns records for a name like marketing.shopname.com</span><br/>
-                    <b>Keep in mind</b>; use an url without https://. ]]></comment>
+                    <comment><![CDATA[<span>When a value is present in this field, data will send to this url instead of https://www.googletagmanager.com.
+                    Default output: https://gtm-test123.uc.r.appspot.com. Create a cname in the dns records for a name like marketing.shopname.com</span><br/>
+                    <b>Keep in mind</b>; enter a full url (with https://). ]]></comment>
                 </field>
                 <field id="debug" type="select" translate="label" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Debug</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,7 +33,7 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="serverside_gtm_url" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="serverside_gtm_url" type="text" translate="label" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Container URL</label>
                     <comment><![CDATA[<span>When a value is present in this field, data will send to this url instead of https://www.googletagmanager.com.
                     Default output: https://gtm-test123.uc.r.appspot.com. Create a cname in the dns records for a name like marketing.shopname.com</span><br/>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,6 +33,12 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="serverside_gtm_url" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Container URL</label>
+                    <comment><![CDATA[<span>When a value is present in this field, data will send to this url instead of www.googletagmanager.com.
+                    Default output: gtm-test123.uc.r.appspot.com. Create a cname in the dns records for a name like marketing.shopname.com</span><br/>
+                    <b>Keep in mind</b>; use an url without https://. ]]></comment>
+                </field>
                 <field id="debug" type="select" translate="label" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Debug</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -11,7 +11,7 @@ $config = $block->getConfig();
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        'https://<?= $config->getGoogleTagmanagerUrl() ?>/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','<?= $config->getId() ?>');</script>
 
 <script>

--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -11,7 +11,7 @@ $config = $block->getConfig();
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://<?= $config->getGoogleTagmanagerUrl() ?>/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        '<?= $config->getGoogleTagmanagerUrl() ?>/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','<?= $config->getId() ?>');</script>
 
 <script>


### PR DESCRIPTION
…back for default gtm url. Get this url in template and make it available in config.php and commoms.phh viewmodel