### PR TITLE
execute begin_checkout event using checkout step navigator

### DIFF
--- a/DataLayer/Event/BeginCheckout.php
+++ b/DataLayer/Event/BeginCheckout.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\GoogleTagManager2\DataLayer\Event;
+
+use Magento\Quote\Model\Quote;
+use Yireo\GoogleTagManager2\Api\Data\EventInterface;
+use Yireo\GoogleTagManager2\DataLayer\Tag\Cart\CartItems;
+use Yireo\GoogleTagManager2\DataLayer\Tag\Cart\CartValue;
+use Yireo\GoogleTagManager2\DataLayer\Tag\CurrencyCode;
+
+class BeginCheckout implements EventInterface
+{
+    private Quote $quote;
+    private CartItems $cartItems;
+    private CartValue $cartValue;
+    private CurrencyCode $currencyCode;
+
+    /**
+     * @param Quote $quote
+     * @param CartItems $cartItems
+     * @param CartValue $cartValue
+     * @param CurrencyCode $currencyCode
+     */
+    public function __construct(
+        Quote $quote,
+        CartItems $cartItems,
+        CartValue $cartValue,
+        CurrencyCode $currencyCode
+    ) {
+        $this->quote = $quote;
+        $this->cartItems = $cartItems;
+        $this->cartValue = $cartValue;
+        $this->currencyCode = $currencyCode;
+    }
+
+    public function get(): array
+    {
+        return [
+            'event' => 'begin_checkout',
+            'ecommerce' => [
+                'currency' => $this->currencyCode->get(),
+                'value' => $this->cartValue->get(),
+                'coupon' => $this->quote->getCouponCode(),
+                'items' => $this->cartItems->get()
+            ]
+        ];
+    }
+}

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -16,18 +16,21 @@
                 <argument name="data_layer_processors" xsi:type="array">
                     <item name="checkout" xsi:type="object">Yireo\GoogleTagManager2\DataLayer\Processor\Checkout</item>
                 </argument>
-
-                <argument name="data_layer_events" xsi:type="array">
-                    <item name="begin_checkout" xsi:type="array">
-                        <item name="event" xsi:type="string">begin_checkout</item>
-                        <item name="ecommerce" xsi:type="array">
-                            <item name="items" xsi:type="object">Yireo\GoogleTagManager2\DataLayer\Tag\Cart\CartItems
-                            </item>
-                        </item>
-                    </item>
-                </argument>
             </arguments>
         </referenceBlock>
+
+        <referenceContainer name="yireo_googletagmanager2.data-layer.container">
+            <block
+                    name="yireo_googletagmanager2.script-begin-checkout"
+                    template="Yireo_GoogleTagManager2::luma/script-begin-checkout.phtml"
+                    ifconfig="googletagmanager2/settings/enabled"
+                    after="yireo_googletagmanager2.data-layer"
+            >
+                <arguments>
+                    <argument name="begin_checkout_event" xsi:type="object">Sanders\GoogleTagManager2\DataLayer\Event\BeginCheckout</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
 
         <referenceBlock name="checkout.root">
             <arguments>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -22,6 +22,9 @@ var config = {
             /*'Magento_Catalog/js/catalog-add-to-cart': {
                 'Yireo_GoogleTagManager2/js/mixins/catalog-add-to-cart-mixin': false
             },*/
+            'Magento_Checkout/js/model/step-navigator': {
+                'Yireo_GoogleTagManager2/js/mixins/step-navigator-mixin': true
+            }
         }
     }
 };

--- a/view/frontend/templates/luma/script-begin-checkout.phtml
+++ b/view/frontend/templates/luma/script-begin-checkout.phtml
@@ -1,0 +1,7 @@
+<?php
+/** @var \Yireo\GoogleTagManager2\DataLayer\Event\BeginCheckout $beginCheckoutEvent */
+$beginCheckoutEvent = $block->getData('begin_checkout_event');
+?>
+<script>
+    window['YIREO_GOOGLETAGMANAGER2_BEGIN_CHECKOUT'] = <?= json_encode($beginCheckoutEvent->get()) ?>
+</script>

--- a/view/frontend/web/js/mixins/step-navigator-mixin.js
+++ b/view/frontend/web/js/mixins/step-navigator-mixin.js
@@ -1,0 +1,28 @@
+define([
+    'mage/utils/wrapper',
+    'yireoGoogleTagManagerLogger'
+], function (wrapper, logger, stepNavigator) {
+    'use strict';
+
+    return function (stepNavigator) {
+
+        stepNavigator.steps.subscribe(function (steps){
+
+            if (steps[0].isVisible()) {
+
+                const gtmData = window['YIREO_GOOGLETAGMANAGER2_BEGIN_CHECKOUT'];
+
+                if (gtmData === null) {
+                    logger('skipped "begin_checkout" event because data is empty')
+                }
+
+                logger('page event "begin_checkout" (js)', gtmData);
+
+                window.dataLayer.push({ ecommerce: null });
+                window.dataLayer.push(gtmData);
+            }
+        });
+
+        return stepNavigator;
+    }
+});


### PR DESCRIPTION
Might require refactoring or maybe you disagree on firing the begin_checkout event this way.

The issue was that the `begin_checkout` event fired multiple times.

The `begin_checkout` event is removed from `checkout_index_index.xml` and replaced with a new block to pass the event's data via the new mixin.

It's executed when the first step on the checkout is active. Returning to the first step (reloading or navigating from step 2 back to step 1) will trigger the `begin_checkout` event. In GA4 it's possible to filter specific events for it to be unique per user.