### PR TITLE
feature/select-item-event

### DIFF
--- a/view/frontend/web/js/product/clicks.js
+++ b/view/frontend/web/js/product/clicks.js
@@ -6,7 +6,7 @@ define([
         const productPath = config.productPath || '.product-items a.product';
         $(productPath).click(function(event) {
             const debugClicks = YIREO_GOOGLETAGMANAGER2_DEBUG_CLICKS || false;
-            const $parent = $(this).parent();
+            const $parent = $(this).closest('[id^=product_item_info_]');
             const regex = /_(\d+)$/;
             const matches = $parent.attr('id').match(regex);
             const productId = matches[1];


### PR DESCRIPTION
`parent()` will retrieve the product_id from the direct parent. This can cause issues when nesting multiple HTML elements.

```html
<div class="product-items">
    <div id="product_item_info_xxx">
        <div class="breaking_wrapper"> <-- will cause issues as new direct parent
            <a href="url.com" class="product"/>
        </div>
    </div>
</div>
```

`.closest()` will retrieve the product_id until attribute id with value `product_item_info_xxx` is found for more flexibility.