### PR TITLE
fix Parse error: syntax error, unexpected ')'

### DIFF
--- a/DataLayer/Tag/EnhancedConversions/Sha256EmailAddress.php
+++ b/DataLayer/Tag/EnhancedConversions/Sha256EmailAddress.php
@@ -19,7 +19,7 @@ class Sha256EmailAddress implements TagInterface
      */
     public function __construct(
         CheckoutSession $checkoutSession,
-        OrderRepositoryInterface $orderRepository,
+        OrderRepositoryInterface $orderRepository
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->orderRepository = $orderRepository;


### PR DESCRIPTION
Magento compilation gives the following error:
Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) in vendor/yireo/magento2-googletagmanager2/DataLayer/Tag/EnhancedConversions/Sha256EmailAddress.php on line 23