### PR TITLE
Fixed bug that causes a lot of errors in console

### DIFF
--- a/view/frontend/templates/hyva/script-additions.phtml
+++ b/view/frontend/templates/hyva/script-additions.phtml
@@ -60,7 +60,10 @@ $commons = $block->getCommonsViewModel();
                         mageCacheStorage = JSON.parse(mageCacheStorage);
                     }
 
-                    delete mageCacheStorage.cart.gtm_events[eventId];
+                    if (typeof mageCacheStorage.cart.gtm_events[eventId] !== undefined) {
+                        delete mageCacheStorage.cart.gtm_events[eventId];
+                    }
+                    
                     window.localStorage.setItem('mage-cache-storage', JSON.stringify(mageCacheStorage));
                 }
             }


### PR DESCRIPTION
Its trying to delete gtm_events from the cache storage, but its not always existing

so check if it exists, then remove the storage key

Thanks to @JCombee for fixing this :)