### PR TITLE
argument name typo fix for hyva_default.xml

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,12 +72,12 @@ A RequireJS mixin is added to `Magento_Catalog/js/catalog-add-to-cart` to trigge
 The datalayer event `removeFromCart` is ideally triggered from JavaScript as well, but unfortunately the JavaScript API is not consistent. Instead, the event `sales_quote_remove_item` is observed by an observer which calls upon the session data provider `\Yireo\GoogleTagManager2\Api\CheckoutSessionDataProviderInterface` to temporarily add the event data to the session and then append this to the `customerData` section. Right.
 
 ## Handling product clicks
-Product clicks are tracked through a specific template called `script-product-clicks`. Make sure the XPath identifier used as the XML layout argument `productPath` is matching with yours. By default, this is `.product-items a.product` in Luma. To change this, use an XML layout instruction like the following:
+Product clicks are tracked through a specific template called `script-product-clicks`. Make sure the XPath identifier used as the XML layout argument `product_path` is matching with yours. By default, this is `.product-items a.product` in Luma. To change this, use an XML layout instruction like the following:
 
 ```xml
 <referenceBlock name="yireo_googletagmanager2.script-product-clicks">
     <arguments>
-        <argument name="productPath" xsi:type="string">.my-products a.product</argument>
+        <argument name="product_path" xsi:type="string">.my-products a.product</argument>
     </arguments>
 </referenceBlock>
 ```

--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -37,7 +37,7 @@
             name="yireo_googletagmanager2.script-product-clicks"
             template="Yireo_GoogleTagManager2::hyva/script-product-clicks.phtml">
             <arguments>
-                <argument name="productPath" xsi:type="string">.products a.product</argument>
+                <argument name="product_path" xsi:type="string">.products a.product</argument>
             </arguments>
         </referenceBlock>
     </body>


### PR DESCRIPTION
The argument name fixed productPath -> product_path

otherwise Hyva themes getting wrong argument data from default.xml instead of hyva_default.xml