### PR TITLE
Fixes a TypeError for MultiSelect attribute values

### DIFF
--- a/Util/Attribute/GetAttributeValue.php
+++ b/Util/Attribute/GetAttributeValue.php
@@ -162,7 +162,9 @@ class GetAttributeValue
             return [];
         }
 
-        $attributeValues = explode(',', $attributeValue);
+        $attributeValues = is_array($attributeValue)
+            ? $attributeValue
+            : explode(',', $attributeValue);
 
         $options = $attribute->getSource()->getAllOptions();
         $attributeLabels = [];


### PR DESCRIPTION
Prevent TypeError when value is already an array.

May provide some unit-tests if times permits it...