### PR TITLE
Performance Improvement: Do Not Load Category Products If Disabled

### DIFF
--- a/Plugin/GetProductsFromCategoryBlockPlugin.php
+++ b/Plugin/GetProductsFromCategoryBlockPlugin.php
@@ -43,7 +43,7 @@ class GetProductsFromCategoryBlockPlugin
         }
         $i = 0;
         foreach ($collection as $product) {
-            if ($maximumCategoryProducts > 0 && $i > $maximumCategoryProducts) {
+            if ($i > $maximumCategoryProducts) {
                 break;
             }
 

--- a/Plugin/GetProductsFromCategoryBlockPlugin.php
+++ b/Plugin/GetProductsFromCategoryBlockPlugin.php
@@ -37,9 +37,13 @@ class GetProductsFromCategoryBlockPlugin
         ListProduct $listProductBlock,
         AbstractCollection $collection
     ): AbstractCollection {
+        $maximumCategoryProducts = $this->config->getMaximumCategoryProducts();
+        if ($maximumCategoryProducts <= 0) {
+            return $collection;
+        }
         $i = 0;
         foreach ($collection as $product) {
-            if ($this->config->getMaximumCategoryProducts() > 0 && $i > $this->config->getMaximumCategoryProducts()) {
+            if ($maximumCategoryProducts > 0 && $i > $maximumCategoryProducts) {
                 break;
             }
 


### PR DESCRIPTION
This is the outcome of a profiling session for a client. This client has very slow filters (next thing to fix ;-)). Even though we set `googletagmanager2/settings/category_products` to `0` in order to disable exporting category products, I saw that the products, related categories and respective filters are still loaded. For my client, this led to the fact that the Yireo data layer block took 700ms :astonished: This PR fixes the issue. Now, if you disable category products, they are not loaded at all.