### PR TITLE
Fatal error: Uncaught Error: Call to a member function getCarrierCode…

### DIFF
--- a/DataLayer/Event/AddShippingInfo.php
+++ b/DataLayer/Event/AddShippingInfo.php
@@ -40,7 +40,7 @@ class AddShippingInfo implements EventInterface
 
         if (!$shippingMethod) {
             $quoteId = $this->checkoutSession->getQuote()->getId();
-            $shippingMethod = $this->getShippingMethodFromQuote($quoteId);
+            $shippingMethod = $this->getShippingMethodFromQuote((int)$quoteId);
         }
 
         if (!$shippingMethod) {

--- a/DataLayer/Event/AddShippingInfo.php
+++ b/DataLayer/Event/AddShippingInfo.php
@@ -40,8 +40,7 @@ class AddShippingInfo implements EventInterface
 
         if (!$shippingMethod) {
             $quoteId = $this->checkoutSession->getQuote()->getId();
-            $shippingMethod = $this->shippingMethodManagement->get($quoteId);
-            $shippingMethod = $shippingMethod->getCarrierCode().'_'.$shippingMethod->getMethodCode();
+            $shippingMethod = $this->getShippingMethodFromQuote($quoteId);
         }
 
         if (!$shippingMethod) {
@@ -55,5 +54,23 @@ class AddShippingInfo implements EventInterface
                 'items' => $this->cartItems->get(),
             ],
         ];
+    }
+
+    /**
+     * Cart2Quote compatibility. When creating a quote there is no shipping info.
+     * shippingMethodManagement returns null and causes error on function getCarrierCode()
+     *
+     * @param int $quoteId
+     * @return string|null
+     */
+    public function getShippingMethodFromQuote(int $quoteId): ?string
+    {
+        $shippingMethod = $this->shippingMethodManagement->get($quoteId);
+        if(!is_null($shippingMethod)) {
+
+            return $shippingMethod->getCarrierCode().'_'.$shippingMethod->getMethodCode();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
When using Cart2Quote module and requesting a quote a fatal error occurs when trying to place the quotation request. 

```
Uncaught Error: Call to a member function getCarrierCode() on null
```

Full trace:
```
<br/><b>Fatal error</b>:  Uncaught Error: Call to a member function getCarrierCode() on null in /var/www/vendor/yireo/magento2-googletagmanager2/DataLayer/Event/AddShippingInfo.php: 44 Stack trace: #0/var/www/vendor/yireo/magento2-googletagmanager2/Plugin/TriggerAddShippingInfoDataLayerEvent.php(38): Yireo\GoogleTagManager2\DataLayer\Event\AddShippingInfo-&gt;get()#1/var/www/vendor/magento/framework/Interception/Interceptor.php(146): Yireo\GoogleTagManager2\Plugin\TriggerAddShippingInfoDataLayerEvent-&gt;afterSaveAddressInformation(Object(Magento\Checkout\Model\ShippingInformationManagement\Interceptor),
Object(Magento\Checkout\Model\PaymentDetails),
167,
Object(Magento\Checkout\Model\ShippingInformation))#2/var/www/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Checkout\Model\ShippingInformationManagement\Interceptor-&gt;Magento\Framework\Interception\{
    closure
}(167,
Object(Magento\Checkout\Model\ShippingInformation)in<b>/var/www/vendor/yireo/magento2-googletagmanager2/DataLayer/Event/AddShippingInfo.php</b> on line <b>44</b><br/>{
    ```

This minor code change prevents this error from happening. 