### PR TITLE
Added telephone for enhanced ecommerce

### DIFF
--- a/DataLayer/Tag/EnhancedConversions/Sha256CustomerTelephone.php
+++ b/DataLayer/Tag/EnhancedConversions/Sha256CustomerTelephone.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Yireo\GoogleTagManager2\DataLayer\Tag\EnhancedConversions;
+
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Yireo\GoogleTagManager2\Api\Data\TagInterface;
+use Yireo\GoogleTagManager2\Config\Config;
+
+class Sha256CustomerTelephone implements TagInterface
+{
+    private CheckoutSession $checkoutSession;
+    private OrderRepositoryInterface $orderRepository;
+
+    /**
+     * @param CheckoutSession $checkoutSession
+     * @param OrderRepositoryInterface $orderRepository
+     */
+    public function __construct(
+        CheckoutSession $checkoutSession,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function get(): string
+    {
+        $order = $this->getOrder();
+        return hash('sha256', trim($order->getBillingAddress()->getTelephone() ?? ''));
+    }
+
+    /**
+     * @return OrderInterface
+     */
+    private function getOrder(): OrderInterface
+    {
+        return $this->orderRepository->get($this->checkoutSession->getLastRealOrder()->getId());
+    }
+}

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -29,6 +29,7 @@
 
                 <argument name="data_layer" xsi:type="array">
                     <item name="sha256_email_address" xsi:type="object">Yireo\GoogleTagManager2\DataLayer\Tag\EnhancedConversions\Sha256EmailAddress</item>
+                    <item name="sha256_customer_telephone" xsi:type="object">Yireo\GoogleTagManager2\DataLayer\Tag\EnhancedConversions\Sha256CustomerTelephone</item>
                 </argument>
             </arguments>
         </referenceBlock>


### PR DESCRIPTION
Added the sha256 telephone number to the datalayer for a question about extending enhanced e-commerce. 
Can we add all the other possible fields like this  (city, region, zip, lastname ...) or should we bundle it for performance issues due to the call to getOrder.