### PR TITLE
Implement argument interface so magento doesn't get confused.

### DIFF
--- a/MageWire/Component.php
+++ b/MageWire/Component.php
@@ -13,7 +13,7 @@ if (class_exists('\Magewirephp\Magewire\Component')) {
         }
     }
 } else {
-    class Component
+    class Component implements ArgumentInterface
     {
         public function isHyvaCheckoutEnabled(): bool
         {


### PR DESCRIPTION
The following issues explains this change a bit more in detail: https://github.com/yireo/Yireo_GoogleTagManager2/issues/218