### PR TITLE
item_list_name on PLP

### DIFF
--- a/Config/Config.php
+++ b/Config/Config.php
@@ -200,6 +200,14 @@ class Config implements ArgumentInterface
     }
 
     /**
+     * @return string
+     */
+    public function getProductListValueOnCategory(): string
+    {
+        return (string)$this->getModuleConfigValue('product_list_value_on_category');
+    }
+
+    /**
      * Return a configuration value
      *
      * @param string $key

--- a/DataLayer/Mapper/ProductDataMapper.php
+++ b/DataLayer/Mapper/ProductDataMapper.php
@@ -2,6 +2,7 @@
 
 namespace Yireo\GoogleTagManager2\DataLayer\Mapper;
 
+use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Pricing\Price\FinalPrice;
 use Magento\Framework\Exception\LocalizedException;
@@ -9,6 +10,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Yireo\GoogleTagManager2\Api\Data\ProductTagInterface;
 use Yireo\GoogleTagManager2\Api\Data\TagInterface;
 use Yireo\GoogleTagManager2\Config\Config;
+use Yireo\GoogleTagManager2\Model\Config\Source\ProductListValue;
 use Yireo\GoogleTagManager2\Util\Attribute\GetAttributeValue;
 use Yireo\GoogleTagManager2\Util\CategoryProvider;
 use Yireo\GoogleTagManager2\Util\PriceFormatter;
@@ -72,7 +74,7 @@ class ProductDataMapper
         }
 
         try {
-            $category = $this->categoryProvider->getFirstByProduct($product);
+            $category = $this->getProductCategory($product);
             $productData[$prefix . 'list_id'] = $category->getId();
             $productData[$prefix . 'list_name'] = $category->getName();
         } catch (NoSuchEntityException $noSuchEntityException) {
@@ -87,6 +89,20 @@ class ProductDataMapper
         // @todo: Add "variant" reference to Configurable Product
 
         return $productData;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @return CategoryInterface
+     */
+    private function getProductCategory($product)
+    {
+        if ($this->config->getProductListValueOnCategory() == ProductListValue::CURRENT_CATEGORY
+            && $product->getCategory()
+        ) {
+            return $product->getCategory();
+        }
+        return $this->categoryProvider->getFirstByProduct($product);
     }
 
     /**

--- a/Model/Config/Source/ProductListValue.php
+++ b/Model/Config/Source/ProductListValue.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Yireo\GoogleTagManager2\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class ProductListValue implements OptionSourceInterface
+{
+    public const PRODUCT_FIRST_CATEGORY = 'product_first_category';
+    public const CURRENT_CATEGORY = 'current_category';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            [
+                'value' => self::PRODUCT_FIRST_CATEGORY,
+                'label' => __('Product First Category'),
+            ],
+            [
+                'value' => self::CURRENT_CATEGORY,
+                'label' => __('Current Category'),
+            ],
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -67,6 +67,13 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="product_list_value_on_category" type="select" translate="label" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Product List Value on Category Page</label>
+                    <source_model>Yireo\GoogleTagManager2\Model\Config\Source\ProductListValue</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
                 <field id="product_eav_attributes" type="multiselect" translate="label" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Product EAV Attributes</label>
                     <source_model>Yireo\GoogleTagManager2\Model\Config\Source\ProductAttributes</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,6 +13,7 @@
                 <customer_eav_attributes>id</customer_eav_attributes>
                 <view_cart_occurances>everywhere</view_cart_occurances>
                 <view_cart_on_mini_cart_expand_only>0</view_cart_on_mini_cart_expand_only>
+                <product_list_value_on_category>product_first_category</product_list_value_on_category>
             </settings>
         </googletagmanager2>
     </default>


### PR DESCRIPTION
Hi @jissereitsma
This is PR for issue https://github.com/yireo/Yireo_GoogleTagManager2/issues/232

It allow to use current category as item_list_name parameter.
I have added below configuration to not break previous functionallity. By default first category is used as  item_list_name parameter but  if needs it can be switched to current category.
- Product List Value on Category Page
   - Product First Category (selected by defualt)
   - Current Category