### PR TITLE
Fix Uncaught TypeError: products.forEach is not a function

### DIFF
--- a/view/frontend/templates/hyva/script-product-clicks.phtml
+++ b/view/frontend/templates/hyva/script-product-clicks.phtml
@@ -28,7 +28,7 @@ $productPath = $block->getProductPath();
     }
 
     const products = document.querySelectorAll('<?= $productPath ?>');
-    if (products) {
+    if (products && products.length > 0) {
         products.forEach(function(product) {
             product.addEventListener('click', function(event, s) {
                 let parentElement = yireoGoogleTagManager2FindParentElementWithName(event.target, 'form');


### PR DESCRIPTION
We're occasionally getting a javascript exception:

Uncaught TypeError: products.forEach is not a function

This is a fix for that issue.