### PR TITLE
Fixed implicitly declared nullable arguments, improves compatibility …

### DIFF
--- a/Plugin/TriggerAddGuestPaymentInfoDataLayerEvent.php
+++ b/Plugin/TriggerAddGuestPaymentInfoDataLayerEvent.php
@@ -31,7 +31,7 @@ class TriggerAddGuestPaymentInfoDataLayerEvent
         $cartId,
         $email,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         $cartId = $this->maskedQuoteIdToQuoteId->execute($cartId);
         $addPaymentInfoEventData = $this->addPaymentInfo
@@ -49,7 +49,7 @@ class TriggerAddGuestPaymentInfoDataLayerEvent
         $cartId,
         $email,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         $cartId = $this->maskedQuoteIdToQuoteId->execute($cartId);
         $addPaymentInfoEventData = $this->addPaymentInfo

--- a/Plugin/TriggerAddPaymentInfoDataLayerEvent.php
+++ b/Plugin/TriggerAddPaymentInfoDataLayerEvent.php
@@ -34,7 +34,7 @@ class TriggerAddPaymentInfoDataLayerEvent
         $orderId,
         $cartId,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         $addPaymentInfoEventData = $this->addPaymentInfo
             ->setPaymentMethod($paymentMethod->getMethod())
@@ -58,7 +58,7 @@ class TriggerAddPaymentInfoDataLayerEvent
         $orderId,
         $cartId,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         $addPaymentInfoEventData = $this->addPaymentInfo
             ->setPaymentMethod($paymentMethod->getMethod())


### PR DESCRIPTION
…with PHP 8.4

Found with [PHPCompatibility phpcs standard](https://github.com/PHPCompatibility/PHPCompatibility) (`develop` branch)
```
$ vendor/bin/phpcs --standard=PHPCompatibility --extensions=php,phtml --runtime-set testVersion 7.4- .

FILE: Plugin/TriggerAddGuestPaymentInfoDataLayerEvent.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 34 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $billingAddress.
 52 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $billingAddress.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: Plugin/TriggerAddPaymentInfoDataLayerEvent.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 37 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $billingAddress.
 61 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $billingAddress.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Time: 608ms; Memory: 6MB
```

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

