### PR TITLE
Add more product click selectors for Hyvä

### DIFF
--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -35,7 +35,7 @@
             name="yireo_googletagmanager2.script-product-clicks"
             template="Yireo_GoogleTagManager2::hyva/script-product-clicks.phtml">
             <arguments>
-                <argument name="product_path" xsi:type="string">.products a.product</argument>
+                <argument name="product_path" xsi:type="string">.products a.product, .products a.product-item-link, .card a.product-item-link, .card a.product-item-photo, .card a.btn-primary</argument>
             </arguments>
         </referenceBlock>
     </body>


### PR DESCRIPTION
* `.products a.product`: Product image on category pages
* `.products a.product-item-link`: Product name on category pages
* `.card a.product-item-link`: Product name in sliders and "product viewed" templates
* `.card a.product-item-photo`: Product image in sliders and "product viewed" templates
* `.card a.btn-primary`: "View Product" button in sliders and "product viewed" templates