### PR TITLE
Fix for event 'add_shipping_info' is not being fired

### DIFF
--- a/DataLayer/Event/AddShippingInfo.php
+++ b/DataLayer/Event/AddShippingInfo.php
@@ -39,13 +39,13 @@ class AddShippingInfo implements EventInterface
      */
     public function get(): array
     {
-        if (false === $this->checkoutSession->hasQuote()) {
-            return [];
-        }
-
         try {
             $quote = $this->checkoutSession->getQuote();
         } catch (NoSuchEntityException|LocalizedException $e) {
+            return [];
+        }
+
+        if (false === $this->checkoutSession->hasQuote()) {
             return [];
         }
 


### PR DESCRIPTION
Hi @jissereitsma ,

We've experience that the quote property on the checkout session was not available and therefor the event was not fired, due the first statement in DataLayer/Event/AddShippingInfo.php's get method. 

The problem is solved by reversing the try-catch and the if statement. This seems to be a safer approach.
We did see that it used to be like that in the past: https://github.com/yireo/Yireo_GoogleTagManager2/commit/0e378f5d4dabbbbc861b9ab5fe10709deb9cc6a0

Good suggestion to revert this?

