### PR TITLE
Fixes some more wrong escaping methods being used in frontend files.

### DIFF
--- a/view/frontend/templates/hyva/script-product-clicks.phtml
+++ b/view/frontend/templates/hyva/script-product-clicks.phtml
@@ -29,7 +29,7 @@ $productPath = $block->getProductPath();
         return yireoGoogleTagManager2FindParentElementWithName(element.parentElement, parentTagName);
     }
 
-    const products = document.querySelectorAll('<?= $escaper->escapeHtml($productPath) ?>');
+    const products = document.querySelectorAll('<?= $escaper->escapeJs($productPath) ?>');
     if (products && products.length > 0) {
         products.forEach(function(product) {
             product.addEventListener('click', function(event, s) {

--- a/view/frontend/templates/iframe.phtml
+++ b/view/frontend/templates/iframe.phtml
@@ -8,5 +8,6 @@ use Yireo\GoogleTagManager2\Config\Config;
 /** @var Config $config */
 /** @var Template $block */
 $config = $block->getConfig();
+$url = sprintf('%s/ns.html?id=%s', $config->getGoogleTagmanagerUrl(), $config->getId());
 ?>
-<noscript><iframe src="<?= $escaper->escapeUrl($config->getGoogleTagmanagerUrl()) ?>/ns.html?id=<?= $escaper->escapeHtml($config->getId()) ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="<?= $escaper->escapeUrl($url) ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/view/frontend/templates/luma/script-product-clicks.phtml
+++ b/view/frontend/templates/luma/script-product-clicks.phtml
@@ -17,6 +17,6 @@ $productPath = $block->getProductPath();
 ?>
 <script>
     require(['yireoGoogleTagManagerProductClicks'], function(clicks) {
-        clicks({productPath: '<?= $escaper->escapeHtml($productPath) ?>'});
+        clicks({productPath: '<?= $escaper->escapeJs($productPath) ?>'});
     });
 </script>

--- a/view/frontend/templates/product/details.phtml
+++ b/view/frontend/templates/product/details.phtml
@@ -21,5 +21,5 @@ $product = $productDetails->getProduct();
 $productData = $dataLayer->toJson($productDetails->merge());
 ?>
 <script>
-    window['YIREO_GOOGLETAGMANAGER2_PRODUCT_DATA_ID_<?= $escaper->escapeHtml($product->getId()) ?>'] = <?= /* @noEscape */ $productData ?>;
+    window['YIREO_GOOGLETAGMANAGER2_PRODUCT_DATA_ID_<?= $escaper->escapeJs($product->getId()) ?>'] = <?= /* @noEscape */ $productData ?>;
 </script>

--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -32,9 +32,9 @@ $events = ($config->waitForUserInteraction() === false)
                     j = d.createElement(s),
                     dl = l != 'dataLayer' ? '&l=' + l : '';
                 j.async = true;
-                j.src = '<?= $escaper->escapeUrl($config->getGoogleTagmanagerUrl()) ?>' + '/gtm.js?id=' + i + dl;
+                j.src = '<?= $escaper->escapeJs($config->getGoogleTagmanagerUrl()) ?>' + '/gtm.js?id=' + i + dl;
                 f.parentNode.insertBefore(j, f);
-            })(window, document, 'script', 'dataLayer', '<?= $escaper->escapeHtml($gtmId) ?>');
+            })(window, document, 'script', 'dataLayer', '<?= $escaper->escapeJs($gtmId) ?>');
             <?php endforeach; ?>
         };
 


### PR DESCRIPTION
The last 2 versions released introduced improved escaping, but it looks like some wrong methods got used.

Especially in the javascript area, you should use `escapeJs` instead of `escapeHtml` (see below for example).
Also, to output an url in javascript, [the documentation](https://developer.adobe.com/commerce/php/development/security/cross-site-scripting/#:~:text=string%20that%20must%20not%20contain%20JS/HTML-,Escaper%20method%3A%20escapeJS,Copy,-%3Cscript%3E) recommends to still use `escapeJs` instead of `escapeUrl`:
> //Do not use HTMl context methods like escapeUrl

Also the url for the `<noscript>` tag was generated in a strange way by escaping parts of the url in 2 different ways, this has been simplified which makes the code more readable and more correct.

Watch out, I've only tested the changes in `iframe.phtml` and `script.phtml` myself, maybe double check the other changes as well yourself.

//cc @jissereitsma 

----

Locally, I created a small proof of this in the `script.phtml` by changing the php variable `$gtmId` to `"test'ing"` as a way to demonstrate the problem.

With the old `escapeHtml` method, this would output: `'test&#039;ing'`, which Javascript interprets as: `test&#039;ing`
With the new `escapeJs` method, this will output: `'test\u0027ing'`, which Javascript interprets as `test'ing` which is what we want.


