### PR TITLE
Add check for allowed_events length in script-pusher

### DIFF
--- a/view/frontend/templates/hyva/script-pusher.phtml
+++ b/view/frontend/templates/hyva/script-pusher.phtml
@@ -44,7 +44,7 @@
             return;
         }
 
-        if (metaData && metaData.allowed_events) {
+        if (metaData && metaData.allowed_events && metaData.allowed_events.length > 0) {
             for (const [allowedEventKey, allowedEvent] of Object.entries(metaData.allowed_events)) {
                 window.addEventListener(allowedEvent, function () {
                     const eventDataCopy = Object.assign({}, eventData);


### PR DESCRIPTION
Add a check to see if allowed_events is not empty so that it skips this condition.